### PR TITLE
Remove sniffs requiring trailing comma

### DIFF
--- a/Syde-Extra/ruleset.xml
+++ b/Syde-Extra/ruleset.xml
@@ -153,9 +153,6 @@
             <property name="allowMultiLine" type="boolean" value="yes" />
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
-    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse" />
-    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR removes three sniffs from the `Syde-Extra` standard.

**What is the current behavior?** (You can also link to an open issue here)

Currently, the following three Slevomat sniffs are part of the `Syde-Extra` standard:

- `SlevomatCodingStandard.Functions.RequireTrailingCommaInCall`
- `SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse`
- `SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration`

These sniffs require a trailing comma in multi-line function calls, closure `use` declarations, and function declarations, respectively.

On PHP 7.4., such a trailing comma is invalid, though, making it harder to use PHP_CodeSniffer across PHP 7.4 and newer.

**What is the new behavior (if this is a feature change)?**

The above three sniffs have been removed from the `Syde-Extra` standard. This means that trailing are still supported/allowed, but no longer required, which allows writing code that is valid across PHP 7.4+.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
