### PR TITLE
Update PHPStan integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The Syde PHP Coding Standards package requires:
 
 When installed for local development, these packages will be installed as well:
 
-- [PHPStan](https://github.com/phpstan/phpstan/) 2.0+
+- [PHPStan](https://github.com/phpstan/phpstan/) 2.1+
+- [PHPStan Deprecation Rules Extension](https://github.com/phpstan/phpstan-deprecation-rules) 2.0+
+- [PHPStan No-Private Extension](https://github.com/swissspidy/phpstan-no-private) 1.0+
 - [PHPUnit](https://github.com/sebastianbergmann/phpunit/) 10.5+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,10 @@
         "wp-coding-standards/wpcs": "^3.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.5"
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpunit/phpunit": "^10.5",
+        "swissspidy/phpstan-no-private": "^1.0"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - vendor/swissspidy/phpstan-no-private/rules.neon
 parameters:
     level: 9
     paths:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add two PHPStan extensions.

**What is the current behavior?** (You can also link to an open issue here)

No PHPStan extensions.

**What is the new behavior (if this is a feature change)?**

The PHPStan setup now includes both the `phpstan/phpstan-deprecation-rules` and the `swissspidy/phpstan-no-private` extension.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
